### PR TITLE
feat: add mailpitDeleteEmailsBySearch command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This package supports TypeScript out of the box.
     - [mailpitGetMail](#mailpitgetmailid)
     - [mailpitSendMail](#mailpitsendmailoptions)
     - [mailpitDeleteAllEmails](#mailpitdeleteallmails)
+    - [mailpitDeleteEmailsBySearch](#mailpitdeleteemailsbysearchquery-string)
   - Email Assertions
     - [mailpitHasEmailsBySearch](#mailpithasemailsbysearchquery-start--0-limit--50--timeout--10000-interval--500-)
     - [mailpitNotHasEmailsBySearch](#mailpitnothasemailsbysearchquery-start--0-limit--50--timeout--4000-interval--500-)
@@ -255,6 +256,14 @@ Deletes all stored mails from Mailpit.
 
 ```JavaScript
 cy.mailpitDeleteAllEmails();
+```
+
+#### mailpitDeleteEmailsBySearch(query: string)
+
+Deletes emails from the mailbox based on the search query.
+
+```JavaScript
+cy.mailpitDeleteEmailsBySearch('subject:Test');
 ```
 
 

--- a/cypress.d.ts
+++ b/cypress.d.ts
@@ -195,6 +195,12 @@ declare global {
 			mailpitDeleteAllEmails(): Chainable<void>;
 
 			/**
+			 * Delete emails from the mailbox based on search query.
+			 * @param query Search query to delete emails
+			 */
+			mailpitDeleteEmailsBySearch(query: string): Chainable<void>;
+
+			/**
 			 * Set the read status of one or more emails to read.
 			 * @param messages Array of Message or MessageSummary objects to mark as read
 			 */

--- a/cypress/e2e/mailpit.cy.ts
+++ b/cypress/e2e/mailpit.cy.ts
@@ -268,7 +268,6 @@ describe("mailpit read status test", () => {
 	});
 });
 
-
 describe("mailpit delete test", () => {
 	beforeEach(() => {
 		cy.mailpitDeleteAllEmails();

--- a/cypress/e2e/mailpit.cy.ts
+++ b/cypress/e2e/mailpit.cy.ts
@@ -267,3 +267,30 @@ describe("mailpit read status test", () => {
 		}
 	});
 });
+
+
+describe("mailpit delete test", () => {
+	beforeEach(() => {
+		cy.mailpitDeleteAllEmails();
+	});
+
+	afterEach(() => {
+		cy.mailpitDeleteAllEmails();
+	});
+
+	it("should delete emails by search query", () => {
+		cy.mailpitSendMail({
+			subject: "Delete Me",
+			textBody: "Test",
+		});
+		cy.mailpitSendMail({
+			subject: "No Delete",
+			textBody: "Test",
+		});
+
+		cy.mailpitDeleteEmailsBySearch("subject:Delete Me");
+
+		cy.mailpitHasEmailsBySubject("No Delete");
+		cy.mailpitNotHasEmailsBySubject("Delete Me");
+	});
+});

--- a/src/MailpitCommands.ts
+++ b/src/MailpitCommands.ts
@@ -7,6 +7,7 @@ class MailpitCommands {
 	static get parentCypressCommands(): string[] {
 		return [
 			"mailpitDeleteAllEmails",
+			"mailpitDeleteEmailsBySearch",
 			"mailpitGetAllMails",
 			"mailpitGetEmailsBySubject",
 			"mailpitGetMail",
@@ -224,6 +225,17 @@ class MailpitCommands {
 		return cy.request({
 			method: "DELETE",
 			url: this.mailpitUrl("/v1/messages"),
+			auth: this.auth,
+		});
+	}
+
+	mailpitDeleteEmailsBySearch(query: string): Cypress.Chainable<Cypress.Response<void>> {
+		return cy.request({
+			method: "DELETE",
+			url: this.mailpitUrl("/v1/search"),
+			qs: {
+				query: query,
+			},
 			auth: this.auth,
 		});
 	}


### PR DESCRIPTION
Resolved #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command `mailpitDeleteEmailsBySearch` for deleting emails based on a search query, enhancing email management capabilities.
	- Updated the README for easy navigation and usage examples of the new command.
- **Bug Fixes**
	- Corrected documentation for the deprecated method `mailpitGetMailSpamAssainSummary` to guide users towards the correct usage.
- **Tests**
	- Added a new test suite and case to validate the functionality of deleting emails by search query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->