### PR TITLE
Migrate from Cypress.env() to Cypress.expose() and cy.env()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ Include this package into your Cypress command file:
 import 'cypress-mailpit';
 ```
 
-Add the base URL of your Mailpit installation in the `e2e` block of your `cypress.config.ts` / `cypress.config.js`:
+Add the base URL of your Mailpit installation in the `expose` block of your `cypress.config.ts` / `cypress.config.js`:
 
 ```typescript
 export default defineConfig({
   projectId: "****",
-  env: {
+  expose: {
     MAILPIT_URL: "http://localhost:8025",
   },
 });
@@ -88,14 +88,35 @@ export default defineConfig({
 
 ### Mailpit authentication (Basic Auth)
 
-Add `MAILPIT_USERNAME` and `MAILPIT_PASSWORD` in Cypress env config:
+Add `MAILPIT_USERNAME` and `MAILPIT_PASSWORD` in the `env` block of your Cypress config:
 
-```json
-{
-  "MAILPIT_USERNAME": "mailpit username",
-  "MAILPIT_PASSWORD": "mailpit password"
-}
+```typescript
+export default defineConfig({
+  env: {
+    MAILPIT_USERNAME: "mailpit username",
+    MAILPIT_PASSWORD: "mailpit password",
+  },
+});
 ```
+
+### Migrating to v2
+
+v2 requires **Cypress >= 15.10.0**. The main change is that `MAILPIT_URL` has moved from `env` to `expose` in your Cypress config:
+
+```diff
+ export default defineConfig({
++  expose: {
++    MAILPIT_URL: "http://localhost:8025",
++  },
+   env: {
+-    MAILPIT_URL: "http://localhost:8025",
+     MAILPIT_USERNAME: "admin",
+     MAILPIT_PASSWORD: "admin",
+   },
+ });
+```
+
+`Cypress.expose()` is a synchronous API for non-sensitive values, while `cy.env()` is used for sensitive credentials like passwords. No changes are needed to your test code — all `cy.mailpitXxx()` commands work the same as before.
 
 ## Commands
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,9 +7,11 @@ export default defineConfig({
 	e2e: {
 		setupNodeEvents(_on, _config) {},
 	},
+	expose: {
+		MAILPIT_URL: "http://localhost:8025",
+	},
 	env: {
 		BASE_URL: "http://localhost:8025",
-		MAILPIT_URL: "http://localhost:8025",
 		MAILPIT_USERNAME: "admin",
 		MAILPIT_PASSWORD: "admin",
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
 	"name": "cypress-mailpit",
-	"version": "1.4.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cypress-mailpit",
-			"version": "1.4.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.4",
 				"cypress": "^15.11.0",
 				"typescript": "^5.9.3"
+			},
+			"peerDependencies": {
+				"cypress": ">=15.10.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -1755,9 +1758,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cypress-mailpit",
-	"version": "1.4.0",
+	"version": "2.0.0",
 	"description": "Cypress Commands for Mailpit 💌",
 	"main": "rewrite/index.js",
 	"types": "cypress.d.ts",
@@ -33,6 +33,9 @@
 		"url": "https://github.com/pushpak1300/cypress-mailpit/issues"
 	},
 	"homepage": "https://github.com/pushpak1300/cypress-mailpit#readme",
+	"peerDependencies": {
+		"cypress": ">=15.10.0"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.4",
 		"cypress": "^15.11.0",


### PR DESCRIPTION
`Cypress.env()` is deprecated in Cypress 15.10 and will be removed in Cypress 16. This migrates the plugin to the new APIs, splitting config by sensitivity: `Cypress.expose()` for public values like the Mailpit URL, and `cy.env()` for sensitive credentials.

### Usage

```diff
 export default defineConfig({
+  expose: {
+    MAILPIT_URL: "http://localhost:8025",
+  },
   env: {
-    MAILPIT_URL: "http://localhost:8025",
     MAILPIT_USERNAME: "admin",
     MAILPIT_PASSWORD: "admin",
   },
 });
```

### Approach

- The constructor reads the Mailpit URL synchronously via `Cypress.expose()` instead of `Cypress.env()`
- Credentials are resolved per-request using the async `cy.env()` command, removing the stored auth field
- All request-making methods go through a single helper that chains auth resolution with `cy.request()`
- Version bumped to 2.0.0 with a peer dependency on Cypress >= 15.10.0

> [!WARNING]
> **Breaking change:** Requires Cypress >= 15.10.0. Users must move `MAILPIT_URL` from the `env` block to the `expose` block in their Cypress config. See the migration guide in the README.