### PR TITLE
Remove stale release script re-added by PR #63

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	"scripts": {
 		"dev": "npm run build && npm run cy:dev",
 		"test": "cypress run --headless",
-		"release": "standard-version",
 		"check": "oxlint && oxfmt --check",
 		"format": "oxfmt",
 		"lint": "oxlint",


### PR DESCRIPTION
## Summary
- PR #64 removed the `release: standard-version` script from package.json, but PR #63 was branched before that merge and accidentally re-introduced it
- `standard-version` is not a dependency, so this script was broken anyway

## Test plan
- [x] `npm run check` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)