### PR TITLE
Include README in published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"types": "cypress.d.ts",
 	"files": [
 		"dist",
-		"cypress.d.ts"
+		"cypress.d.ts",
+		"README.md"
 	],
 	"scripts": {
 		"dev": "npm run build && npm run cy:dev",


### PR DESCRIPTION
## Summary
- Add `README.md` to the `files` array in `package.json` so it's included in the published npm package
- Fixes the npm warning: "This package does not have a README"

## Test plan
- [ ] Run `npm pack --dry-run` and verify `README.md` is listed in the tarball contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)